### PR TITLE
Move Started notification to correct method

### DIFF
--- a/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
+++ b/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
@@ -173,9 +173,11 @@ class NonBlockingProcess(
             .fromGraph(new PublishIfAvailable[ByteString])
             .toMat(BroadcastHub.sink)(Keep.both)
             .run
-        parent ! Started(nuProcess.getPID, stdin, stdout, stderr)
 
         nuProcess.setProcessHandler(new NuAbstractProcessHandler {
+          override def onStart(nuProcess: NuProcess): Unit =
+            parent ! Started(nuProcess.getPID, stdin, stdout, stderr)
+
           override def onStderr(buffer: ByteBuffer, closed: Boolean): Unit =
             if (!closed)
               err.publishIfAvailable(() => ByteString.fromByteBuffer(buffer))

--- a/src/test/resources/loop.sh
+++ b/src/test/resources/loop.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-logger my pid is $$
+pid=$$
 
-trap 'logger killing $$; kill -9 $$' SIGTERM
+trap 'kill -9 $pid' SIGTERM
+
+printf "Starting"
 
 1>&2 sleep 8 &
 wait

--- a/src/test/scala/akka/contrib/process/BlockingProcessSpec.scala
+++ b/src/test/scala/akka/contrib/process/BlockingProcessSpec.scala
@@ -89,6 +89,8 @@ class BlockingProcessSpec extends WordSpec with Matchers with BeforeAndAfterAll 
 
       probe.watch(process)
 
+      probe.expectMsg(Receiver.Out("Starting"))
+
       process ! BlockingProcess.Destroy
 
       probe.fishForMessage(5.seconds) {

--- a/src/test/scala/akka/contrib/process/NonBlockingProcessSpec.scala
+++ b/src/test/scala/akka/contrib/process/NonBlockingProcessSpec.scala
@@ -94,6 +94,8 @@ class NonBlockingProcessSpec extends WordSpec with Matchers with BeforeAndAfterA
 
       exitProbe.watch(process)
 
+      streamProbe.expectMsg(NonBlockingReceiver.Out("Starting"))
+
       process ! NonBlockingProcess.Destroy
 
       exitProbe.fishForMessage(5.seconds) {


### PR DESCRIPTION
`onPreStart` happens before the process has been started -- `Started` shouldn't be signaled until `onStart`.

Because of this, sometimes the calls to `nuProcess.writeStdin` from the test case would happen before the process was started.

Additionally, `getPID` always returned 0 before this change as the process was never started at the point of the `Started` message being sent. Probably want a test on the PID behavior as well.