### PR TITLE
Actually fix broken test logic

### DIFF
--- a/src/test/resources/loop.sh
+++ b/src/test/resources/loop.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+# The idea here is to start a child (sleep 10) that will live on after we've
+# sigkilled ourselves -- which happens when we trap a sigterm
+
 pid=$$
+trap "kill -9 $pid" TERM
+sleep 10 &
+printf ready
 
-trap 'kill -9 $pid' SIGTERM
-
-printf "Starting"
-
-1>&2 sleep 8 &
-wait
+while true; do
+    sleep 1
+done


### PR DESCRIPTION
This PR updates the orphaned test and better describes its intent.

It's left `ignore` for `NonBlockingProcessSpec` as it isn't expected to pass there until a polling mechanism is implemented.

It's fixed on `BlockingProcessSpec` - things just weren't quite right and there was a race condition (being killed before forking child) in the test which is now fixed.