### PR TITLE
Disable shutdown hook

### DIFF
--- a/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
+++ b/src/main/scala/akka/contrib/process/NonBlockingProcess.scala
@@ -152,6 +152,8 @@ class NonBlockingProcess(
   val process: NuProcess = {
     import JavaConverters._
 
+    System.setProperty("com.zaxxer.nuprocess.enableShutdownHook", "false")
+
     val pb = new NuProcessBuilder(command.asJava)
 
     pb.environment().putAll(environment.asJava)


### PR DESCRIPTION
This disables the shutdown hook that nuprocess does, thus allowing us to control what happens during shutdown.